### PR TITLE
Memoized cleanseSchema.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -383,7 +383,7 @@ module.exports = (function() {
           data[value] = utils.prepareValue(data[value]);
         });
 
-        var schema = cleanseSchema(collection.waterline.schema, connectionName);
+        var schema = cleanseSchemaMemo(collection.waterline.schema, connectionName);
         var _query;
 
         var sequel = new Sequel(schema, sqlOptions);
@@ -445,7 +445,7 @@ module.exports = (function() {
             data[value] = utils.prepareValue(data[value]);
           });
 
-          var schema = cleanseSchema(collection.waterline.schema, connectionName);
+          var schema = cleanseSchemaMemo(collection.waterline.schema, connectionName);
           var _query;
 
           var sequel = new Sequel(schema, sqlOptions);
@@ -570,7 +570,7 @@ module.exports = (function() {
             });
 
             // Build Query
-            var _schema = cleanseSchema(collection.waterline.schema, connectionName);
+            var _schema = cleanseSchemaMemo(collection.waterline.schema, connectionName);
 
             var sequel = new Sequel(_schema, sqlOptions);
             var _query;
@@ -816,7 +816,7 @@ module.exports = (function() {
         var collection = connectionObject.collections[collectionName];
 
         // Build find query
-        var schema = cleanseSchema(collection.waterline.schema, connectionName);
+        var schema = cleanseSchemaMemo(collection.waterline.schema, connectionName);
         var _query;
 
         var sequel = new Sequel(schema, sqlOptions);
@@ -946,7 +946,7 @@ module.exports = (function() {
         var collection = connectionObject.collections[collectionName];
 
         // Build find query
-        var schema = cleanseSchema(collection.waterline.schema, connectionName);
+        var schema = cleanseSchemaMemo(collection.waterline.schema, connectionName);
         var _query;
 
         var sequel = new Sequel(schema, sqlOptions);
@@ -1037,7 +1037,7 @@ module.exports = (function() {
         var tableName = collectionName;
 
         // Build query
-        var schema = cleanseSchema(collection.waterline.schema, connectionName);
+        var schema = cleanseSchemaMemo(collection.waterline.schema, connectionName);
 
         var _query;
 
@@ -1223,7 +1223,7 @@ module.exports = (function() {
    * @param {Object} schema
    */
 
-  function cleanseSchema (schema, connectionName) {
+  var cleanseSchemaMemo = _.memoize(function(schema, connectionName) {
     var _schema = _.cloneDeep(schema);
 
     _.each(_.keys(schema), function(key) {
@@ -1242,7 +1242,15 @@ module.exports = (function() {
     });
 
     return _schema;
-  }
+  },
+  // the memoize resolver is below.
+  // the result is unique up to the connectionName,
+  // since this adapter doesn't support multiple
+  // connections of the same name in different waterline instances.
+  function(schema, connectionName) {
+    
+    return connectionName;
+  });
 
 })();
 


### PR DESCRIPTION
Since `cleanseSchema` is called on every query, and it does quite a bit of work in `_.cloneDeep`, I think the results need to be cached somehow.  I decided to use lodash's memoize method: https://lodash.com/docs#memoize

Most likely a slightly better solution is to compute the cleansed schema when the connection is registered, but I sadly don't have time to make that refactor right now!  I'd store it here on the `connections` object, which is shared by the adapter definition: https://github.com/particlebanana/sails-mysql/blob/updated_sequel/lib/connections/register.js#L35-L40
